### PR TITLE
Added /bloggers route

### DIFF
--- a/src/controllers/blog-controller.js
+++ b/src/controllers/blog-controller.js
@@ -9,6 +9,14 @@ export function getAllPosts(pageNumber) {
   });
 }
 
+export function getBloggerPosts(vanityName, pageNumber) {
+  return api.get('posts', {
+    vanity_name: vanityName,
+    page: pageNumber - 1,
+    page_size: PAGE_SIZE
+  });
+}
+
 export function getPostAuthors(posts) {
   // Add posts author IDs to array
   const ids = posts.map(post => post.author_id);
@@ -28,4 +36,8 @@ export function getPostAuthors(posts) {
     }
     return postsWithAuthors;
   });
+}
+
+export function getPageSize() {
+  return PAGE_SIZE;
 }

--- a/src/controllers/blogger-controller.js
+++ b/src/controllers/blogger-controller.js
@@ -1,0 +1,20 @@
+import * as api from '../helpers/api';
+
+const PAGE_SIZE = 16;
+
+export function getAllBloggers(pageNumber) {
+  return api.get('users', {
+    page: pageNumber - 1,
+    page_size: PAGE_SIZE
+  });
+}
+
+export function getSingleBlogger(vanityName) {
+  return api.get('users', {
+    vanity_name: vanityName
+  });
+}
+
+export function getPageSize() {
+  return PAGE_SIZE;
+}

--- a/src/helpers/handlebars.js
+++ b/src/helpers/handlebars.js
@@ -33,10 +33,10 @@ export function formatDateLong(datestamp) {
 export function urlFormat(urlStr) {
   let url = urlStr;
 
-  if (url && url.lastIndexOf('http://', 0) === 0) {
+  if (url && url.startsWith('http://')) {
     url = url.substring(7);
 
-    if (url.lastIndexOf('www.', 0) === 0) {
+    if (url.startsWith('www.')) {
       url = url.substring(4);
     }
   }

--- a/src/helpers/handlebars.js
+++ b/src/helpers/handlebars.js
@@ -30,6 +30,19 @@ export function formatDateLong(datestamp) {
   }
 }
 
+export function urlFormat(urlStr) {
+  let url = urlStr;
+
+  if (url && url.lastIndexOf('http://', 0) === 0) {
+    url = url.substring(7);
+
+    if (url.lastIndexOf('www.', 0) === 0) {
+      url = url.substring(4);
+    }
+  }
+  return url;
+}
+
 export function section(name, options) {
   if (!this._sections) {
     this._sections = {};

--- a/src/helpers/handlebars.js
+++ b/src/helpers/handlebars.js
@@ -16,7 +16,7 @@ export function formatDateShort(datestamp) {
       return date.format('MMM D, YYYY');
     }
     return date.fromNow();
-  } catch (error) {
+  } catch (err) {
     return '';
   }
 }
@@ -25,22 +25,27 @@ export function formatDateLong(datestamp) {
   try {
     const date = moment(datestamp);
     return date.format('MMMM D, YYYY h:mm a');
-  } catch (error) {
+  } catch (err) {
     return '';
   }
 }
 
 export function urlFormat(urlStr) {
-  let url = urlStr;
+  let url = urlStr || '';
 
-  if (url && url.startsWith('http://')) {
-    url = url.substring(7);
+  try {
+    if (url.startsWith('http://')) {
+      url = url.substring(7);
+    } else if (url.startsWith('https://')) {
+      url = url.substring(8);
+    }
 
     if (url.startsWith('www.')) {
       url = url.substring(4);
     }
+  } finally {
+    return url;
   }
-  return url;
 }
 
 export function section(name, options) {

--- a/src/public/styles/bloggers.scss
+++ b/src/public/styles/bloggers.scss
@@ -1,5 +1,9 @@
 @import 'variables';
 
+hr {
+  margin-top: 30px;
+}
+
 .blogger-list {
   width: 100%;
   min-height: 75px;
@@ -14,7 +18,6 @@
   width: 10em; // 160px
   margin-left: 1.15em; // 18px
   margin-right: 1.15em;
-  //margin-top: 24px;
   height: 13.125em;
 }
 
@@ -24,7 +27,7 @@ h2 {
   font-size: 1.125em;
 }
 
-main a {
+.site-link {
   height: 1.2em;
   margin: 2px 0;
   font-size: 0.875em;
@@ -37,8 +40,8 @@ main a {
 }
 
 .avatar {
-  width: 8.75em;
-  height: 8.75em;
+  width: 7.66em;
+  height: 7.66em;
   margin: 0 auto;
   display: block;
 }

--- a/src/public/styles/bloggers.scss
+++ b/src/public/styles/bloggers.scss
@@ -1,0 +1,55 @@
+@import 'variables';
+
+.blogger-list {
+  width: 100%;
+  min-height: 75px;
+  margin: 0 auto;
+  margin-top: 24px;
+  overflow: hidden;
+  text-align: center;
+}
+
+.blogger-item {
+  display: inline-block;
+  width: 10em; // 160px
+  margin-left: 1.15em; // 18px
+  margin-right: 1.15em;
+  //margin-top: 24px;
+  height: 13.125em;
+}
+
+h2 {
+  margin-top: 0.375em;
+  margin-bottom: 0.25em;
+  font-size: 1.125em;
+}
+
+main a {
+  height: 1.2em;
+  margin: 2px 0;
+  font-size: 0.875em;
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  text-decoration: none;
+  color: #999;
+}
+
+.avatar {
+  width: 8.75em;
+  height: 8.75em;
+  margin: 0 auto;
+  display: block;
+}
+
+@media screen and (max-width: 800px) {
+  main {
+    padding: 0;
+    font-size: 14px;
+  }
+
+  .blogger-item {
+    margin: 0 0.5em;
+  }
+}

--- a/src/public/styles/index.scss
+++ b/src/public/styles/index.scss
@@ -108,54 +108,6 @@ article footer {
   text-decoration: underline;
 }
 
-#nav-pages {
-  margin: 18px 8px 0 8px;
-}
-
-#nav-pages::after {
-  content: '';
-  clear: both;
-  display: block;
-}
-
-.page-btn {
-  position: relative;
-  text-decoration: none;
-
-  svg {
-    width: 18px;
-    margin: 0 4px;
-    fill: $link-color;
-  }
-
-  p {
-    font-family: $sans-serif-font;
-    font-size: 20px;
-    color: $link-color;
-    line-height: 1em;
-    margin: 0;
-    margin-top: 6px;
-    vertical-align: top;
-  }
-
-  * {
-    display: inline-block;
-  }
-}
-
-.page-btn:hover * {
-  color: $accent-color;
-  fill: $accent-color;
-}
-
-#newer {
-  float: left;
-}
-
-#older {
-  float: right;
-}
-
 @media screen and (max-width: 1130px) {
   article footer {
     padding: 0;

--- a/src/public/styles/main.scss
+++ b/src/public/styles/main.scss
@@ -141,6 +141,54 @@ hr {
   object-fit: cover;
 }
 
+#nav-pages {
+  margin: 18px 8px 0 8px;
+}
+
+#nav-pages::after {
+  content: '';
+  clear: both;
+  display: block;
+}
+
+.page-btn {
+  position: relative;
+  text-decoration: none;
+
+  svg {
+    width: 18px;
+    margin: 0 4px;
+    fill: $link-color;
+  }
+
+  p {
+    font-family: $sans-serif-font;
+    font-size: 20px;
+    color: $link-color;
+    line-height: 1em;
+    margin: 0;
+    margin-top: 6px;
+    vertical-align: top;
+  }
+
+  * {
+    display: inline-block;
+  }
+}
+
+.page-btn:hover * {
+  color: $accent-color;
+  fill: $accent-color;
+}
+
+#newer {
+  float: left;
+}
+
+#older {
+  float: right;
+}
+
 #body-footer {
   height: 100px;
   margin: 0 auto;

--- a/src/routes/blogger-routes.js
+++ b/src/routes/blogger-routes.js
@@ -1,29 +1,28 @@
 import express from 'express';
-import * as blogController from '../controllers/blog-controller';
+import * as bloggerController from '../controllers/blogger-controller';
 
 const router = express.Router(); // eslint-disable-line new-cap
 
 router.get('/', (req, res, next) => {
   const pageNumber = req.query.page || 1;
 
-  blogController.getAllPosts(pageNumber)
-    .then(blogController.getPostAuthors)
-    .then(posts => {
-      if (posts.length === 0) {
+  bloggerController.getAllBloggers(pageNumber)
+    .then(bloggers => {
+      if (bloggers.length === 0) {
         res.render('info', {
-          title: 'No more posts',
-          description: 'No more posts to read.'
+          title: 'No more bloggers',
+          description: 'No more bloggers to see.'
         });
       } else {
-        const hasMore = posts.length === blogController.getPageSize();
+        const hasMore = bloggers.length === bloggerController.getPageSize();
         const hasLess = pageNumber > 1;
 
-        res.render('index', {
-          title: 'Home',
+        res.render('bloggers', {
+          title: 'Bloggers',
           hasMore,
           hasLess,
           pageNumber,
-          posts
+          bloggers
         });
       }
     })

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import log from './log';
 import configureHelmet from './security/configure-helmet';
 import requestLogger from './log/request-logger';
 import indexRoute from './routes/index-route';
+import bloggerRoutes from './routes/blogger-routes';
 import * as errorRoutes from './routes/error-routes';
 import * as hbsHelpers from './helpers/handlebars';
 
@@ -16,6 +17,7 @@ app.use(requestLogger);
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRoute);
+app.use('/bloggers', bloggerRoutes);
 app.use(errorRoutes.notFoundHandler);
 app.use(errorRoutes.errorHandler);
 

--- a/src/views/bloggers.handlebars
+++ b/src/views/bloggers.handlebars
@@ -1,0 +1,42 @@
+{{#section 'css'}}
+<link rel="stylesheet" href="/styles/bloggers.css">
+{{/section}}
+
+{{#section 'meta'}}
+<meta name="description" content="Computer Science Blogs is the feed aggregation service for the writings of Computer Science students, academics, researchers and those in industry listed here."/>
+<meta property="og:title" content="List of Computer Science Bloggers"/>
+<meta property="og:description" content="Computer Science Blogs is the feed aggregation service for the writings of Computer Science students, academics, researchers and those in industry listed here."/>
+{{/section}}
+
+<ul class="blogger-list">
+  {{#each bloggers}}
+  <li class="blogger-item" itemscope itemprop="author" itemtype="https://schema.org/Person">
+    <a class="avatar" href="/bloggers/{{vanity_name}}" itemprop="sameAs">
+      <img class="avatar" src="{{profile_picture_uri}}" alt="Avatar" itemprop="image"/>
+    </a>
+    <h2>
+      <span itemprop="givenName">{{first_name}}</span>
+      <span itemprop="familyName">{{last_name}}</span>
+    </h2>
+    <a href="{{website_uri}}" itemprop="url">{{urlFormat website_uri}}</a>
+  </li>
+  {{/each}}
+</ul>
+<div id="nav-pages">
+  {{#if hasLess}}
+  <a id="newer" class="page-btn" href="/bloggers?page={{add pageNumber -1}}">
+    <svg viewbox="0 0 37.62 67.32">
+      <use xlink:href="/images/defs.svg#left-arrow"></use>
+    </svg>
+    <p>Previous</p>
+  </a>
+  {{/if}}
+  {{#if hasMore}}
+  <a id="older" class="page-btn" href="/bloggers?page={{add pageNumber 1}}">
+    <p>Next</p>
+    <svg viewbox="0 0 37.62 67.32">
+      <use xlink:href="/images/defs.svg#right-arrow"></use>
+    </svg>
+  </a>
+  {{/if}}
+</div>

--- a/src/views/bloggers.handlebars
+++ b/src/views/bloggers.handlebars
@@ -18,7 +18,7 @@
       <span itemprop="givenName">{{first_name}}</span>
       <span itemprop="familyName">{{last_name}}</span>
     </h2>
-    <a href="{{website_uri}}" itemprop="url">{{urlFormat website_uri}}</a>
+    <a class="site-link" href="{{website_uri}}" itemprop="url">{{urlFormat website_uri}}</a>
   </li>
   {{/each}}
 </ul>

--- a/src/views/end-of-posts.handlebars
+++ b/src/views/end-of-posts.handlebars
@@ -1,1 +1,0 @@
-<h2 class="serif-header">No more posts to read.</h2>

--- a/src/views/index.handlebars
+++ b/src/views/index.handlebars
@@ -48,10 +48,12 @@
     <p>Newer</p>
   </a>
   {{/if}}
+  {{#if hasMore}}
   <a id="older" class="page-btn" href="/?page={{add pageNumber 1}}">
     <p>Older</p>
     <svg viewbox="0 0 37.62 67.32">
       <use xlink:href="/images/defs.svg#right-arrow"></use>
     </svg>
   </a>
+  {{/if}}
 </div>

--- a/src/views/info.handlebars
+++ b/src/views/info.handlebars
@@ -1,0 +1,1 @@
+<h2 class="serif-header">{{description}}</h2>


### PR DESCRIPTION
- Imported /bloggers HTML and CSS from old repo.
- Added `blogger-controller` and renamed `index-controller` to `blog-controller` so it can deal with more actions to do with the /posts route.
- Repurposed/renamed `end-of-posts.handlebars` to `info.handlebars` to show generic messages for both index and blogger pages.
- New feature: pagination on the bloggers page instead of one long list.