### PR TITLE
Added url referral confirmation before deleting user

### DIFF
--- a/src/routes/account-routes.js
+++ b/src/routes/account-routes.js
@@ -6,6 +6,7 @@ import { ensureAuthenticated } from '../helpers/authentication';
 
 const router = express.Router(); // eslint-disable-line new-cap
 const isProduction = process.env.NODE_ENV === 'production';
+const BASE_URL = process.env.CSBLOGS_BASE_URL || process.env.NOW_URL;
 
 /* eslint-disable no-param-reassign */
 function setAvatarCookie(res, blogger) {
@@ -146,6 +147,12 @@ router.get('/confirm-delete', ensureAuthenticated, (req, res) => {
 
 router.get('/delete-account', ensureAuthenticated, async (req, res, next) => {
   try {
+    if (req.get('Referrer') !== `${BASE_URL}/confirm-delete`) {
+      const error = new Error('Request has not been confirmed by the user.');
+      error.status = 400;
+      throw error;
+    }
+
     const data = await bloggerController.deleteUser(req.cookies.user_token);
 
     if (data.status === 200) {

--- a/src/views/confirm-delete.handlebars
+++ b/src/views/confirm-delete.handlebars
@@ -9,5 +9,5 @@
 </div>
 <div id="delete-btns">
     <a id="cancel-button" class="button" href="javascript:history.back()">Cancel</a>
-    <a id="submit-button" class="button" href="/delete-account">Delete</a>
+    <a id="submit-button" class="button" href="/delete-account" referrerpolicy="same-origin">Delete</a>
 </div>


### PR DESCRIPTION
Not to stop malicious intent, but instead to prevent users from navigating to `/delete-account` without first choosing to delete from the `/confirm-delete` page.