### PR TITLE
Added referrer meta tag

### DIFF
--- a/src/views/confirm-delete.handlebars
+++ b/src/views/confirm-delete.handlebars
@@ -1,13 +1,16 @@
+{{#section 'meta'}}
+<meta name="referrer" content="always">
+{{/section}}
 {{#section 'css'}}
 <link rel="stylesheet" href="{{asset '/styles/login.css' 0}}">
 {{/section}}
 
 <h2 class="subheader">Confirm account deletion</h2>
 <div id="delete-txt">
-    <p>Are you sure you want to delete your account and all of your blog posts from CS Blogs?</p>
-    <p>This action cannot be undone!</p>
+  <p>Are you sure you want to delete your account and all of your blog posts from CS Blogs?</p>
+  <p>This action cannot be undone!</p>
 </div>
 <div id="delete-btns">
-    <a id="cancel-button" class="button" href="javascript:history.back()">Cancel</a>
-    <a id="submit-button" class="button" href="/delete-account" referrerpolicy="same-origin">Delete</a>
+  <a id="cancel-button" class="button" href="javascript:history.back()">Cancel</a>
+  <a id="submit-button" class="button" href="/delete-account">Delete</a>
 </div>

--- a/src/views/layouts/main.handlebars
+++ b/src/views/layouts/main.handlebars
@@ -8,6 +8,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#bd030c">
     <meta name="theme-color" content="#bd030c">
+    <meta name="referrer" content="origin">
     {{{_sections.meta}}}
     <link rel="stylesheet" href="{{asset '/styles/main.css' 0}}">
     {{{_sections.css}}}


### PR DESCRIPTION
Unfortunately, we probably can't use the most up-to-date spec because Edge and Safari [don't support it yet](http://caniuse.com/#feat=referrer-policy) 🙄. I also had to replace `referrerpolicy` anchor property with meta `always` as both Chrome and Safari didn't use it to override the page level `origin` policy. Hmmm.